### PR TITLE
Add long description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2022-06-09
+## [1.0.1] - 2022-07-14
+
+- Set `long_description` of package to contents of `README.md`.
+
+## [1.0.0] - 2022-07-14
 
 - Initial release.

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,26 @@
 # Copyright 2022 Block, Inc.
 """Package configuration."""
 
+import os
+
 import setuptools
+
+
+def long_description():
+    """Generate long_description from project README."""
+    cwd = os.path.abspath(os.path.dirname(__file__))
+    readme_path = os.path.join(cwd, "README.md")
+    assert os.path.exists(readme_path), "README.md not found"
+    return open(readme_path, "r").read()
+
 
 setuptools.setup(
     name="pyfu-usb",
     author="Block, Inc.",
     license="MIT",
-    version="1.0.0",
-    description="Python device firmware update utility",
+    version="1.0.1",
+    description="Python USB firmware update library.",
+    long_description=long_description(),
     packages=setuptools.find_packages(),
     python_requires=">=3.7",
     package_data={


### PR DESCRIPTION
_Please explain the changes you made here._

The PyPi page for this project is pretty empty:
https://pypi.org/project/pyfu-usb/

Let's a `long_description` field to the package to fill it up.

_Does this close any currently open issues?_

No.

_Checklist:_

- [x] [Individual Contributor License Agreement (CLA)](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed
