### PR TITLE
Ignore all USB errors when exiting DFU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2022-08-15
+
+- Ignore all `USBError` exceptions when exiting DFU mode.
+
 ## [1.0.1] - 2022-07-14
 
 - Set `long_description` of package to contents of `README.md`.

--- a/pyfu_usb/__init__.py
+++ b/pyfu_usb/__init__.py
@@ -138,10 +138,7 @@ def _dfuse_download(
     try:
         dfu.download(dev, interface, 0, None)
     except usb.core.USBError as err:
-        if "Pipe error" in str(err):
-            logger.warning("Ignoring pipe error when reading final status")
-        else:
-            raise err
+        logger.warning("Ignoring USB error when exiting DFU: %s", err)
 
 
 def _dfu_download(
@@ -182,10 +179,7 @@ def _dfu_download(
     try:
         dfu.download(dev, interface, 0, None)
     except usb.core.USBError as err:
-        if "Pipe error" in str(err):
-            logger.warning("Ignoring pipe error when reading final status")
-        else:
-            raise err
+        logger.warning("Ignoring USB error when exiting DFU: %s", err)
 
 
 def list_devices(vid: Optional[int] = None, pid: Optional[int] = None) -> None:

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     name="pyfu-usb",
     author="Block, Inc.",
     license="MIT",
-    version="1.0.1",
+    version="1.0.2",
     description="Python USB firmware update library.",
     long_description=long_description(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
_Please explain the changes you made here._

When exiting DFU mode, except any `USBError` that could come from `pyusb`. I observed on macOS that doing a DFU with the STM32F2 lead to a new error when exiting DFU mode:

```
ERROR    DFU download failed: USBError(5, 'Input/Output Error')
```

This change is consistent with `pydfu.py`, which the code for this package was originally taken from:
https://github.com/micropython/micropython/blob/master/tools/pydfu.py#L285-L293

_Does this close any currently open issues?_

No

_Checklist:_

- [x] [Individual Contributor License Agreement (CLA)](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed
