### PR TITLE
Bump version 2.0.2, fix CODEOWNERS syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
-* @bbrown1867
-* @hkpeprah
-* @mdmedley
+* @bbrown1867 @hkpeprah @mdmedley

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyfu-usb"
-version = "2.0.1"
+version = "2.0.2"
 requires-python = ">=3.8"
 authors = [{name = "Block, Inc."}]
 description = "Python USB firmware update library."

--- a/uv.lock
+++ b/uv.lock
@@ -395,7 +395,7 @@ wheels = [
 
 [[package]]
 name = "pyfu-usb"
-version = "2.0.1"
+version = "2.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "pyusb" },


### PR DESCRIPTION
_Please explain the changes you made here._

Bump package version to 2.0.2, I forgot to this in #12.

_Does this close any currently open issues?_

No.

_Checklist:_

- [x] [Individual Contributor License Agreement (CLA)](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed
