### PR TITLE
Fix mixed use of tabs and spaces in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,18 +35,18 @@ dev-dependencies = [
 line-length = 80
 indent-width = 4
 exclude = [
-	".coverage",
+    ".coverage",
     ".eggs",
     ".git",
-	".mypy_cache",
-	".pytest_cache",
-	".ruff_cache",
-	".venv",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
     ".vscode",
-	"build",
-	"dist",
-	"htmlcov",
-	"venv",
+    "build",
+    "dist",
+    "htmlcov",
+    "venv",
 ]
 
 [tool.ruff.lint]


### PR DESCRIPTION
_Please explain the changes you made here._

Fix mixed use of tabs and spaces in `pyproject.toml`.

Also just want to check that that the `CODEOWNERS` files changes in #13 are working...

_Does this close any currently open issues?_

No

_Checklist:_

- [x] [Individual Contributor License Agreement (CLA)](https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1) signed
